### PR TITLE
Just Matchers and preparing for reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 tags
+.DS_Store
 
 # Xcode
 #

--- a/Sources/spec.swift
+++ b/Sources/spec.swift
@@ -94,7 +94,8 @@ public struct TestResult {
     public enum State {
         case passed
         case failed
-        case typeMismatch // TODO: include the expected and actual types if possible
+        case typeMismatched // TODO: include the expected and actual types if possible
+        // TODO: add a mismatching values?
 
         init(passed: Bool) {
             if passed {
@@ -176,7 +177,7 @@ public func == <T>(_ expression: Expression<Optional<T>>, _ expected: T) -> Test
     where T: Equatable
 {
     guard let actual = expression.actual else {
-        return .typeMismatch
+        return .typeMismatched
     }
 
     return .init(passed: actual == expected)
@@ -186,7 +187,7 @@ public func != <T>(_ expression: Expression<Optional<T>>, _ expected: T) -> Test
     where T: Equatable
 {
     guard let actual = expression.actual else {
-        return .typeMismatch
+        return .typeMismatched
     }
 
     return .init(passed: actual != expected)

--- a/Sources/spec.swift
+++ b/Sources/spec.swift
@@ -135,9 +135,15 @@ private func execute(_ groups: [Group]) {
 
 // Matchers
 
-extension Expression where T: Sequence {
+extension Expression where T: Sequence, T.Iterator.Element: Equatable {
     public func contain(_ value: T.Iterator.Element) -> TestResult {
-        return TestResult()
+        let actual = expression()
+
+        if actual.contains(value) {
+            return TestResult()
+        } else {
+            return TestResult()
+        }
     }
 }
 

--- a/Sources/spec.swift
+++ b/Sources/spec.swift
@@ -60,6 +60,8 @@ public class Context {
         currentGroup.append(.left(context))
 
         closure(context)
+
+        _ = currentGroup.popLast()
     }
 
     public func it(_ name: String, _ closure: @escaping () -> TestResult.State) {
@@ -154,6 +156,12 @@ private func execute(_ groups: [Group]) {
 }
 
 // Matchers
+
+extension Expression where T: Collection {
+    public func beEmpty() -> TestResult.State {
+        return .init(passed: actual.isEmpty)
+    }
+}
 
 extension Expression where T: Sequence, T.Iterator.Element: Equatable {
     public func contain(_ value: T.Iterator.Element) -> TestResult.State {

--- a/Sources/spec.swift
+++ b/Sources/spec.swift
@@ -77,9 +77,15 @@ public class Context {
     }
 }
 
-/* private extension Array where Element == Step { */
-/* } */
+public struct Expression<T> {
+    let expression: () -> T
+    /* let location: */ 
 
+    public var to: Expression { return self }
+}
+
+public struct TestResult<T> {
+}
 
 public func describe(_ name: String, _ closure: @escaping (Context) -> Void) {
     let context = Context(name: name)
@@ -87,6 +93,10 @@ public func describe(_ name: String, _ closure: @escaping (Context) -> Void) {
     currentGroup = [.left(context)]
 
     closure(context)
+}
+
+public func expect<T>(_ expression: @autoclosure @escaping () -> T) -> Expression<T> {
+    return Expression(expression: expression)
 }
 
 private var currentGroup: Group = {
@@ -113,6 +123,12 @@ private func execute(_ groups: [Group]) {
 
             context.afters.forEach { $0() }
         }
+    }
+}
+
+extension Expression where T: Sequence {
+    public func contain(_ value: T.Iterator.Element) -> TestResult<T> {
+        return TestResult()
     }
 }
 

--- a/Tests/specTests/specTests.swift
+++ b/Tests/specTests/specTests.swift
@@ -64,10 +64,7 @@ func testSpec() {
 
         $0.after { cat.sleep() }
 
-        // FIXME:
-        //  expected: Cat - did not sleep - passed
-        //       got: Cat - when being feed - did not sleep - passed
-        $0.it("did not sleep") { expect(cat.actions.last) != .sleep }
+        $0.it("did not sleep") { expect(cat.actions).to.beEmpty() }
     }
 }
 

--- a/Tests/specTests/specTests.swift
+++ b/Tests/specTests/specTests.swift
@@ -49,7 +49,7 @@ func testSpec() {
 
         $0.context("when being fed") {
             $0.before { cat.feed(.fish) }
-            $0.it("eats") { /* expect(cat.actions).contains(.eat(.food)) */ }
+            $0.it("eats") { expect(cat.actions).to.contain(.eat(.fish)) }
             $0.it("meows") { /* expect(cat.actions.last) == .meow */ }
         }
 

--- a/Tests/specTests/specTests.swift
+++ b/Tests/specTests/specTests.swift
@@ -14,10 +14,18 @@ struct Cat {
     enum Food {
         case fish
     }
-    enum Action {
+    enum Action: Equatable {
         case eat(Food)
         case meow
         case sleep
+        static func ==(lhs: Action, rhs: Action) -> Bool {
+            switch (lhs, rhs) {
+                case let (.eat(l), .eat(r)): return l == r
+                case (.meow, .meow): return true
+                case (.sleep, .sleep): return true
+                default: return false
+            }
+        }
     }
 
     var actions: [Action] = []

--- a/Tests/specTests/specTests.swift
+++ b/Tests/specTests/specTests.swift
@@ -50,11 +50,11 @@ func testSpec() {
         $0.context("when being fed") {
             $0.before { cat.feed(.fish) }
             $0.it("eats") { expect(cat.actions).to.contain(.eat(.fish)) }
-            $0.it("meows") { /* expect(cat.actions.last) == .meow */ }
+            $0.it("meows") { expect(cat.actions.last) == .meow }
         }
 
         $0.after { cat.sleep() }
-        $0.it("did not sleep") { /* expect(cat.actions.last) != .sleep */ }
+        $0.it("did not sleep") { expect(cat.actions.last) != .sleep }
     }
 }
 

--- a/Tests/specTests/specTests.swift
+++ b/Tests/specTests/specTests.swift
@@ -65,8 +65,8 @@ func testSpec() {
         $0.after { cat.sleep() }
 
         // FIXME:
-        //  expected: Cat - did not sleep
-        //       got: Cat - when being feed - did not sleep
+        //  expected: Cat - did not sleep - passed
+        //       got: Cat - when being feed - did not sleep - passed
         $0.it("did not sleep") { expect(cat.actions.last) != .sleep }
     }
 }

--- a/Tests/specTests/specTests.swift
+++ b/Tests/specTests/specTests.swift
@@ -18,6 +18,7 @@ struct Cat {
         case eat(Food)
         case meow
         case sleep
+
         static func ==(lhs: Action, rhs: Action) -> Bool {
             switch (lhs, rhs) {
                 case let (.eat(l), .eat(r)): return l == r
@@ -62,6 +63,10 @@ func testSpec() {
         }
 
         $0.after { cat.sleep() }
+
+        // FIXME:
+        //  expected: Cat - did not sleep
+        //       got: Cat - when being feed - did not sleep
         $0.it("did not sleep") { expect(cat.actions.last) != .sleep }
     }
 }


### PR DESCRIPTION
Now `expect` works!

Limited choice of matchers tho, as shown in the following snippet

```swift
expect(cat.actions).to.contain(.eat(.fish)) 
expect(cat.actions.last) == .meow 
expect(cat.actions.last) != .meow 
expect(cat.actions).to.beEmpty() 
```


The last line is kind of the WIP test report.
```
[[Cat, when being fed, eats], [Cat, when being fed, meows], [Cat, did not sleep]]
eat
meow
sleep
eat
meow
sleep
sleep
[[Cat, when being fed, eats passed], [Cat, when being fed, meows passed], [Cat, did not sleep passed]]
```